### PR TITLE
feat: geoservice reconfiguration

### DIFF
--- a/qsitg/qsitg.py
+++ b/qsitg/qsitg.py
@@ -24,6 +24,8 @@ from qgis.PyQt.QtWidgets import (
 
 from .config import ARCGISFEATURESERVERS, AUTH_SETTING_ID, VECTORTILES
 from .qsitg_dialog import QsitgDialog
+from qgis.utils import pluginMetadata
+import hashlib
 
 KEY_CONFIG_DONE = "configuration_done_flag"
 KEY_DONT_SHOW_AGAIN = "dont_show_again"
@@ -49,7 +51,9 @@ class Qsitg:
         plugin_menu = self.iface.pluginMenu()
         if plugin_menu is None:
             raise RuntimeError("couldn't load plugin menu")
-        self.menu = plugin_menu.addMenu(icon, "SITG")
+        self.menu = plugin_menu.addMenu(
+            icon, f"{self.get_metadata_name} - v{self.get_metadata_version}"
+        )
 
         self.action_about = QAction(icon, "À propos du SITG...")
         self.action_about.triggered.connect(self.run_about)
@@ -81,6 +85,11 @@ class Qsitg:
                 self.run_about()
             if not self.settings.contains(KEY_CONFIG_DONE):
                 self.run_prompt_reset_geoservices()
+
+        # Check geoservices at the end of plugin intialization
+        self.iface.initializationCompleted.connect(
+            self.run_need_to_reset_geoservices
+        )
 
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
@@ -130,6 +139,46 @@ class Qsitg:
     def run_open_guide(self):
         """Open the SITG QGIS user guide in the default web browser."""
         webbrowser.open_new_tab("https://sitg.ge.ch/ressources/le-sitg-avec-qgis")
+
+    def run_need_to_reset_geoservices(self) -> None:
+
+        # Get settings
+        settings = QgsSettings()
+
+        # Recompute current hash
+        current_hash = self.current_config_hash
+
+        # Get actual stored hash
+        stored_hash = settings.value("qsitg/config_hash", None)
+
+        # Log
+        self.log("Need to reset geoservices ?")
+
+        # If stored_hash exists and no change detected, do nothing
+        if stored_hash is not None and stored_hash == current_hash:
+            return True
+        
+        # Compute message in box
+        msgBox = QMessageBox(
+            QMessageBox.Icon.Question,
+            "Nouvelle configuration des geoservices",
+            "<p> Une nouvelle configuration des geoservices est disponible, voulez vous recharger ? </p>",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        msgBox.setDefaultButton(QMessageBox.StandardButton.No)
+        resp = msgBox.exec()
+
+        # If yes reset geoservices
+        if resp == QMessageBox.StandardButton.Yes:
+
+            # Log
+            self.log("Reset Geoservices : YES.")
+
+            # Store new hash
+            settings.setValue("qsitg/config_hash", current_hash)
+        
+            # Run prompt reset command
+            self.run_prompt_reset_geoservices()
 
     def run_prompt_reset_geoservices(self):
         """Prompt the user to configure SITG geoservices authentication."""
@@ -239,4 +288,21 @@ class Qsitg:
             "Les geoservices du SITG ont été (re)configurés avec succès et sont prêts à être utilisés.",
             Qgis.MessageLevel.Success,
         )
+        self.settings.setValue("qsitg/config_hash", self.current_config_hash)
         self.settings.setValue(KEY_CONFIG_DONE, "ok")
+
+    @property
+    def get_metadata_version(self):
+        return pluginMetadata("qsitg", "version")
+
+    @property    
+    def get_metadata_name(self):
+        return pluginMetadata("qsitg", "name")
+    
+    @property
+    def current_config_hash(self):
+        data = {
+            "arcgis": ARCGISFEATURESERVERS,
+            "vectortiles": VECTORTILES,
+        }
+        return hashlib.md5(json.dumps(data, sort_keys=True).encode()).hexdigest()

--- a/qsitg/qsitg.py
+++ b/qsitg/qsitg.py
@@ -12,7 +12,7 @@ from qgis.core import (
 )
 from qgis.gui import QgisInterface
 from qgis.PyQt.QtCore import QItemSelectionModel, Qt
-from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon, QPixmap
 from qgis.PyQt.QtWidgets import (
     QAction,
     QApplication,
@@ -156,21 +156,40 @@ class Qsitg:
 
         # Compute message in box
         msgBox = QMessageBox(
-            QMessageBox.Icon.Question,
+            QMessageBox.Icon.NoIcon,
             "Nouvelle configuration des geoservices",
-            "<p> Une nouvelle configuration des geoservices est disponible, voulez vous recharger ? </p>",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            "<p><b>SITG Etat de Genève<b><p><p>Une nouvelle configuration est disponible, voulez-vous reconfigurer les géoservices du SITG ?</p>",
+            QMessageBox.StandardButton.Yes,
         )
-        msgBox.setDefaultButton(QMessageBox.StandardButton.No)
-        resp = msgBox.exec()
+
+        # Remplace l’icône standard par une image personnalisée
+        base_path = os.path.dirname(__file__)
+        image_path = os.path.join(base_path, "resources", "etat_geneve.png")
+        pixmap = QPixmap(image_path)
+        msgBox.setIconPixmap(pixmap.scaledToWidth(64))
+
+        # Create yes button
+        yes_button = msgBox.button(QMessageBox.StandardButton.Yes)
+
+        # Create ask later button
+        msgBox.addButton(
+            "Me le rappeler plus tard",
+            QMessageBox.ButtonRole.ActionRole,
+        )
+
+        msgBox.setDefaultButton(yes_button)
+        msgBox.exec()
+
+        # Get content
+        if msgBox.clickedButton() == yes_button:
+            resp = QMessageBox.StandardButton.Yes
+        else:
+            resp = "later"
 
         # If yes reset geoservices
         if resp == QMessageBox.StandardButton.Yes:
             # Log
             self.log("Reset Geoservices : YES.")
-
-            # Store new hash
-            settings.setValue("qsitg/config_hash", current_hash)
 
             # Run prompt reset command
             self.run_prompt_reset_geoservices()

--- a/qsitg/qsitg.py
+++ b/qsitg/qsitg.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import webbrowser
@@ -50,9 +51,7 @@ class Qsitg:
         plugin_menu = self.iface.pluginMenu()
         if plugin_menu is None:
             raise RuntimeError("couldn't load plugin menu")
-        self.menu = plugin_menu.addMenu(
-            icon, f"{self.get_metadata_name} - v{self.get_metadata_version}"
-        )
+        self.menu = plugin_menu.addMenu(icon, f"{self.get_metadata_name} - v{self.get_metadata_version}")
 
         self.action_about = QAction(icon, "À propos du SITG...")
         self.action_about.triggered.connect(self.run_about)
@@ -153,7 +152,7 @@ class Qsitg:
 
         # If stored_hash exists and no change detected, do nothing
         if stored_hash is not None and stored_hash == current_hash:
-            return True
+            return None
 
         # Compute message in box
         msgBox = QMessageBox(
@@ -304,4 +303,4 @@ class Qsitg:
             "arcgis": ARCGISFEATURESERVERS,
             "vectortiles": VECTORTILES,
         }
-        return hashlib.md5(json.dumps(data, sort_keys=True).encode()).hexdigest()
+        return hashlib.md5(json.dumps(data, sort_keys=True).encode(), usedforsecurity=False).hexdigest()

--- a/qsitg/qsitg.py
+++ b/qsitg/qsitg.py
@@ -138,6 +138,7 @@ class Qsitg:
         webbrowser.open_new_tab("https://sitg.ge.ch/ressources/le-sitg-avec-qgis")
 
     def run_need_to_reset_geoservices(self) -> None:
+        """Check if hash has change, ask to run the reconfiguration."""
         # Get settings
         settings = QgsSettings()
 
@@ -288,14 +289,17 @@ class Qsitg:
 
     @property
     def get_metadata_version(self):
+        """Get version from metadata."""
         return pluginMetadata("qsitg", "version")
 
     @property
     def get_metadata_name(self):
+        """Get name from metadata."""
         return pluginMetadata("qsitg", "name")
 
     @property
     def current_config_hash(self):
+        """Generate config hash with actual config."""
         data = {
             "arcgis": ARCGISFEATURESERVERS,
             "vectortiles": VECTORTILES,

--- a/qsitg/qsitg.py
+++ b/qsitg/qsitg.py
@@ -21,11 +21,10 @@ from qgis.PyQt.QtWidgets import (
     QStyle,
     QTreeView,
 )
+from qgis.utils import pluginMetadata
 
 from .config import ARCGISFEATURESERVERS, AUTH_SETTING_ID, VECTORTILES
 from .qsitg_dialog import QsitgDialog
-from qgis.utils import pluginMetadata
-import hashlib
 
 KEY_CONFIG_DONE = "configuration_done_flag"
 KEY_DONT_SHOW_AGAIN = "dont_show_again"
@@ -87,9 +86,7 @@ class Qsitg:
                 self.run_prompt_reset_geoservices()
 
         # Check geoservices at the end of plugin intialization
-        self.iface.initializationCompleted.connect(
-            self.run_need_to_reset_geoservices
-        )
+        self.iface.initializationCompleted.connect(self.run_need_to_reset_geoservices)
 
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
@@ -141,7 +138,6 @@ class Qsitg:
         webbrowser.open_new_tab("https://sitg.ge.ch/ressources/le-sitg-avec-qgis")
 
     def run_need_to_reset_geoservices(self) -> None:
-
         # Get settings
         settings = QgsSettings()
 
@@ -157,7 +153,7 @@ class Qsitg:
         # If stored_hash exists and no change detected, do nothing
         if stored_hash is not None and stored_hash == current_hash:
             return True
-        
+
         # Compute message in box
         msgBox = QMessageBox(
             QMessageBox.Icon.Question,
@@ -170,13 +166,12 @@ class Qsitg:
 
         # If yes reset geoservices
         if resp == QMessageBox.StandardButton.Yes:
-
             # Log
             self.log("Reset Geoservices : YES.")
 
             # Store new hash
             settings.setValue("qsitg/config_hash", current_hash)
-        
+
             # Run prompt reset command
             self.run_prompt_reset_geoservices()
 
@@ -295,10 +290,10 @@ class Qsitg:
     def get_metadata_version(self):
         return pluginMetadata("qsitg", "version")
 
-    @property    
+    @property
     def get_metadata_name(self):
         return pluginMetadata("qsitg", "name")
-    
+
     @property
     def current_config_hash(self):
         data = {


### PR DESCRIPTION
Évolution ajoutant une détection automatique des changements de configuration et demandant si l’application d’une reconfiguration des géoservices est souhaitée. 

La détection se déclenche à chaque démarrage de QGIS, une fois le plugin chargé. 

Pour déterminer si une nouvelle configuration est disponible, un hash des configurations stocké dans `qsitg/config_hash` sera utilisé.

Le workfow :
- Lancement de qgis et chargement du plugin
- Check si nouvelle config dispo
- Si non : ne fait rien
- Si oui : Ouvre une popup (yes/no) _ set le nouveau hash _ run la reconfiguration
