### PR TITLE
Fix dialogue reconfigure se lance à chaque démarrage again (suite de #12)

### DIFF
--- a/qsitg/qsitg.py
+++ b/qsitg/qsitg.py
@@ -143,7 +143,7 @@ class Qsitg:
         self.log(f"current hash is: {current_hash}")
 
         # Get actual stored hash
-        stored_hash = self.settings.value("qsitg/config_hash", None)
+        stored_hash = self.settings.value(KEY_CONFIG_HASH, None)
         self.log(f"stored hash is: {stored_hash}")
 
         # If stored_hash exists and no change detected, do nothing


### PR DESCRIPTION
Restait un bug dans #12 (mauvaise clé lors de la lecture des settings)